### PR TITLE
put disk access into background thread?

### DIFF
--- a/alfresco-mobile-android-extensions/alfresco-mobile-android-extension-samsung/src/org/alfresco/mobile/android/application/extension/samsung/pen/SNoteEditorActivity.java
+++ b/alfresco-mobile-android-extensions/alfresco-mobile-android-extension-samsung/src/org/alfresco/mobile/android/application/extension/samsung/pen/SNoteEditorActivity.java
@@ -41,6 +41,7 @@ import android.graphics.Color;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.Html;
 import android.util.DisplayMetrics;
@@ -674,37 +675,45 @@ public class SNoteEditorActivity extends Activity
 
     private void addImgObject(String attachmentKey, float x, float y)
     {
-        SpenObjectImage imgObj = new SpenObjectImage();
-        Bitmap imageBitmap;
-        if (spenNoteDoc.hasAttachedFile(attachmentKey))
-        {
-            if (dm == null)
-            {
-                dm = new DisplayMetrics();
-                ((Activity) context).getWindowManager().getDefaultDisplay().getMetrics(dm);
+        new AsyncTask<Void, Void, Bitmap>() {
+            protected Bitmap doInBackground(Void... args) {
+                Bitmap imageBitmap;
+                if (true)
+                {
+                    if (dm == null)
+                    {
+                        dm = new DisplayMetrics();
+                        ((Activity) context).getWindowManager().getDefaultDisplay().getMetrics(dm);
+                    }
+                    imageBitmap = RenditionManager.decodeFile(new File(spenNoteDoc.getAttachedFile(attachmentKey)),
+                            spenSurfaceView.getCanvasWidth(), dm.densityDpi);
+                }
+                else
+                {
+                    imageBitmap = BitmapFactory.decodeResource(context.getResources(), R.drawable.mime_img);
+                }
+                return imageBitmap;
             }
-            imageBitmap = RenditionManager.decodeFile(new File(spenNoteDoc.getAttachedFile(attachmentKey)),
-                    spenSurfaceView.getCanvasWidth(), dm.densityDpi);
-        }
-        else
-        {
-            imageBitmap = BitmapFactory.decodeResource(context.getResources(), R.drawable.mime_img);
-        }
-        imgObj.setImage(imageBitmap);
 
-        float imgWidth = imageBitmap.getWidth();
-        float imgHeight = imageBitmap.getHeight();
+            protected void onPostExecute(Bitmap imageBitmap) {
+                SpenObjectImage imgObj = new SpenObjectImage();
+                imgObj.setImage(imageBitmap);
 
-        int scale = calculateInSampleSize(imgWidth, imgHeight, spenSurfaceView.getCanvasWidth(),
-                spenSurfaceView.getCanvasHeight());
+                float imgWidth = imageBitmap.getWidth();
+                float imgHeight = imageBitmap.getHeight();
 
-        RectF rect = getRealPoint(x, y, imgWidth / scale, imgHeight / scale);
-        imgObj.setRect(rect, true);
-        spenPageDoc.appendObject(imgObj);
-        spenPageDoc.selectObject(imgObj);
-        spenSurfaceView.update();
+                int scale = calculateInSampleSize(imgWidth, imgHeight, spenSurfaceView.getCanvasWidth(),
+                        spenSurfaceView.getCanvasHeight());
 
-        imageBitmap.recycle();
+                RectF rect = getRealPoint(x, y, imgWidth / scale, imgHeight / scale);
+                imgObj.setRect(rect, true);
+                spenPageDoc.appendObject(imgObj);
+                spenPageDoc.selectObject(imgObj);
+                spenSurfaceView.update();
+
+                imageBitmap.recycle();
+            }
+        }.execute();
     }
 
     // ///////////////////////////////////////////////////////////////////////////

--- a/alfresco-mobile-android/src/org/alfresco/mobile/android/application/accounts/fragment/AccountDetailsFragment.java
+++ b/alfresco-mobile-android/src/org/alfresco/mobile/android/application/accounts/fragment/AccountDetailsFragment.java
@@ -55,6 +55,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.database.Cursor;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.content.LocalBroadcastManager;
@@ -635,9 +636,20 @@ public class AccountDetailsFragment extends BaseFragment
 
     public void displayOAuthFragment()
     {
-        AccountOAuthFragment newFragment = AccountOAuthFragment.newInstance(acc);
-        FragmentDisplayer.replaceFragment(getActivity(), newFragment, DisplayUtils.getMainPaneId(getActivity()),
-                AccountOAuthFragment.TAG, true);
+        new AsyncTask<Void, Void, AccountOAuthFragment>()
+        {
+            protected AccountOAuthFragment doInBackground(Void... args)
+            {
+                AccountOAuthFragment newFragment = AccountOAuthFragment.newInstance(acc);
+                return newFragment;
+            }
+
+            protected void onPostExecute(AccountOAuthFragment newFragment)
+            {
+                FragmentDisplayer.replaceFragment(getActivity(), newFragment, DisplayUtils.getMainPaneId(getActivity()),
+                        AccountOAuthFragment.TAG, true);
+            }
+        }.execute();
     }
 
     // ///////////////////////////////////////////////////////////////////////////

--- a/alfresco-mobile-android/src/org/alfresco/mobile/android/application/accounts/fragment/AccountOAuthFragment.java
+++ b/alfresco-mobile-android/src/org/alfresco/mobile/android/application/accounts/fragment/AccountOAuthFragment.java
@@ -42,6 +42,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
@@ -260,9 +261,20 @@ public class AccountOAuthFragment extends OAuthFragment
     }
 
     private void resetRequest(){
-        AccountOAuthFragment newFragment = AccountOAuthFragment.newInstance();
-        FragmentDisplayer.replaceFragment(getActivity(), newFragment,
-                DisplayUtils.getMainPaneId(getActivity()), AccountOAuthFragment.TAG, true);
+        new AsyncTask<Void, Void, AccountOAuthFragment>()
+        {
+            protected AccountOAuthFragment doInBackground(Void... args)
+            {
+                AccountOAuthFragment newFragment = AccountOAuthFragment.newInstance();
+                return newFragment;
+            }
+
+            protected void onPostExecute(AccountOAuthFragment newFragment)
+            {
+                FragmentDisplayer.replaceFragment(getActivity(), newFragment,
+                        DisplayUtils.getMainPaneId(getActivity()), AccountOAuthFragment.TAG, true);
+            }
+        }.execute();
     }
     
     // ///////////////////////////////////////////////////////////////////////////

--- a/alfresco-mobile-android/src/org/alfresco/mobile/android/application/accounts/fragment/AccountTypesFragment.java
+++ b/alfresco-mobile-android/src/org/alfresco/mobile/android/application/accounts/fragment/AccountTypesFragment.java
@@ -26,6 +26,7 @@ import org.alfresco.mobile.android.application.manager.AccessibilityHelper;
 import org.alfresco.mobile.android.application.utils.UIUtils;
 
 import android.app.DialogFragment;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
@@ -81,9 +82,20 @@ public class AccountTypesFragment extends DialogFragment
             @Override
             public void onClick(View v)
             {
-                AccountOAuthFragment newFragment = AccountOAuthFragment.newInstance();
-                FragmentDisplayer.replaceFragment(getActivity(), newFragment,
-                        DisplayUtils.getMainPaneId(getActivity()), AccountOAuthFragment.TAG, true);
+                new AsyncTask<Void, Void, AccountOAuthFragment>()
+                {
+                    protected AccountOAuthFragment doInBackground(Void... args)
+                    {
+                        AccountOAuthFragment newFragment = AccountOAuthFragment.newInstance();
+                        return newFragment;
+                    }
+
+                    protected void onPostExecute(AccountOAuthFragment newFragment)
+                    {
+                        FragmentDisplayer.replaceFragment(getActivity(), newFragment,
+                                DisplayUtils.getMainPaneId(getActivity()), AccountOAuthFragment.TAG, true);
+                    }
+                }.execute();
             }
         });
 

--- a/alfresco-mobile-android/src/org/alfresco/mobile/android/application/activity/MainActivity.java
+++ b/alfresco-mobile-android/src/org/alfresco/mobile/android/application/activity/MainActivity.java
@@ -100,6 +100,7 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.net.ConnectivityManager;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
@@ -1483,10 +1484,21 @@ public class MainActivity extends BaseActivity
                         || (getFragment(AccountOAuthFragment.TAG) != null && getFragment(AccountOAuthFragment.TAG)
                                 .isAdded()))
                 {
-                    AccountOAuthFragment newFragment = AccountOAuthFragment.newInstance(acc);
-                    FragmentDisplayer.replaceFragment(activity, newFragment, DisplayUtils.getMainPaneId(activity),
-                            AccountOAuthFragment.TAG, true);
-                    DisplayUtils.switchSingleOrTwo(activity, true);
+                    new AsyncTask<Void, Void, AccountOAuthFragment>()
+                    {
+                        protected AccountOAuthFragment doInBackground(Void... args)
+                        {
+                            AccountOAuthFragment newFragment = AccountOAuthFragment.newInstance(acc);
+                            return newFragment;
+                        }
+
+                        protected void onPostExecute(AccountOAuthFragment newFragment)
+                        {
+                            FragmentDisplayer.replaceFragment(activity, newFragment, DisplayUtils.getMainPaneId(activity),
+                                    AccountOAuthFragment.TAG, true);
+                            DisplayUtils.switchSingleOrTwo(activity, true);
+                        }
+                    }.execute();
                     return;
                 }
 

--- a/alfresco-mobile-android/src/org/alfresco/mobile/android/application/operations/batch/capture/AudioCapture.java
+++ b/alfresco-mobile-android/src/org/alfresco/mobile/android/application/operations/batch/capture/AudioCapture.java
@@ -127,7 +127,7 @@ public class AudioCapture extends DeviceCapture
                     }
                 }
                     
-                protected Void doInBackground(Boolean result)
+                protected Void onPostExecute(Boolean result)
                 {
                     if(result == false)
                     {


### PR DESCRIPTION
Hi, I'm doing research on performance for Android apps. I found some event handlers access disk (read/write files) from UI thread, but Android docs suggest us to avoid blocking calls in UI thread. Do they lead to any responsiveness issues in this app?

I tried to refactor them by putting the blocking calls into AsyncTask. Looking forward to see your comments about this issue.