### PR TITLE
ANDROID-564 Wrong German app title after ACS iOS mobile 2.5 and AndroWrong German app title after ACS iOS mobile 2.5 and Android 1.8 releases

### DIFF
--- a/alfresco-mobile-android/src/main/res/values-de/strings.xml
+++ b/alfresco-mobile-android/src/main/res/values-de/strings.xml
@@ -17,7 +17,7 @@
 -->
 <resources>
 
-    <string name="app_name">Inhalt</string>
+    <string name="app_name">Content</string>
     <string name="empty_accounts">Kein Account verfügbar.</string>
 
     <!-- SIGN IN & CREATE ACCOUNT SCREEN -->
@@ -769,8 +769,8 @@
 
     <!-- SHORTCUT & ACTIONS -->
     <string name="select_folder">Auswählen</string>
-    <string name="shortcut_actions_title">Erstellen</string>
-    <string name="shortcut_title">Abkürzung</string>
+    <string name="shortcut_actions_title">Content Services - Erstellen</string>
+    <string name="shortcut_title">Content Services - Abkürzung</string>
     <string name="shortcut_create">Verknüpfung erstellen zu...</string>
     <string name="shortcut_action_create">Aktion definieren...</string>
     <string name="action_associated">Verbundene Aktionen</string>

--- a/alfresco-mobile-android/src/main/res/values-it/strings.xml
+++ b/alfresco-mobile-android/src/main/res/values-it/strings.xml
@@ -17,7 +17,7 @@
 -->
 <resources>
 
-    <string name="app_name">Contenuto</string>
+    <string name="app_name">Content</string>
     <string name="empty_accounts">Nessun account disponibile</string>
 
     <!-- SIGN IN & CREATE ACCOUNT SCREEN -->
@@ -769,8 +769,8 @@
 
     <!-- SHORTCUT & ACTIONS -->
     <string name="select_folder">Seleziona</string>
-    <string name="shortcut_actions_title">Crea</string>
-    <string name="shortcut_title">Scorciatoia</string>
+    <string name="shortcut_actions_title">Content Services: Crea</string>
+    <string name="shortcut_title">Content Services: Scorciatoia</string>
     <string name="shortcut_create">Crea scorciatoia per...</string>
     <string name="shortcut_action_create">Definisci l\'azione...</string>
     <string name="action_associated">Azioni associate</string>

--- a/alfresco-mobile-android/src/main/res/values-ja/strings.xml
+++ b/alfresco-mobile-android/src/main/res/values-ja/strings.xml
@@ -17,7 +17,7 @@
 -->
 <resources>
 
-    <string name="app_name">コンテンツ</string>
+    <string name="app_name">Content</string>
     <string name="empty_accounts">使用できるアカウントがありません</string>
 
     <!-- SIGN IN & CREATE ACCOUNT SCREEN -->
@@ -769,8 +769,8 @@
 
     <!-- SHORTCUT & ACTIONS -->
     <string name="select_folder">選択</string>
-    <string name="shortcut_actions_title">作成</string>
-    <string name="shortcut_title">" ショートカット"</string>
+    <string name="shortcut_actions_title">Content Services - 作成</string>
+    <string name="shortcut_title">Content Services - ショートカット</string>
     <string name="shortcut_create">ショートカットの作成...</string>
     <string name="shortcut_action_create">アクションの定義...</string>
     <string name="action_associated">関連付けられているアクション</string>

--- a/alfresco-mobile-android/src/main/res/values-zh-rCN/strings.xml
+++ b/alfresco-mobile-android/src/main/res/values-zh-rCN/strings.xml
@@ -17,7 +17,7 @@
 -->
 <resources>
 
-    <string name="app_name">内容</string>
+    <string name="app_name">Content</string>
     <string name="empty_accounts">无可用帐户</string>
 
     <!-- SIGN IN & CREATE ACCOUNT SCREEN -->
@@ -769,8 +769,8 @@
 
     <!-- SHORTCUT & ACTIONS -->
     <string name="select_folder">选择</string>
-    <string name="shortcut_actions_title">创建</string>
-    <string name="shortcut_title">" 快捷方式"</string>
+    <string name="shortcut_actions_title">Content Services - 创建</string>
+    <string name="shortcut_title">Content Services - 快捷方式</string>
     <string name="shortcut_create">创建快捷方式...</string>
     <string name="shortcut_action_create">定义您的操作...</string>
     <string name="action_associated">关联的操作</string>

--- a/platform/foundation/src/main/res/values-de/alfresco_strings.xml
+++ b/platform/foundation/src/main/res/values-de/alfresco_strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~  Copyright (C) 2005-2015 Alfresco Software Limited.
   ~
   ~  This file is part of Alfresco Mobile for Android.

--- a/platform/foundation/src/main/res/values-it/alfresco_strings.xml
+++ b/platform/foundation/src/main/res/values-it/alfresco_strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~  Copyright (C) 2005-2015 Alfresco Software Limited.
   ~
   ~  This file is part of Alfresco Mobile for Android.

--- a/platform/foundation/src/main/res/values-ja/alfresco_strings.xml
+++ b/platform/foundation/src/main/res/values-ja/alfresco_strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~  Copyright (C) 2005-2015 Alfresco Software Limited.
   ~
   ~  This file is part of Alfresco Mobile for Android.

--- a/platform/foundation/src/main/res/values-zh-rCN/alfresco_strings.xml
+++ b/platform/foundation/src/main/res/values-zh-rCN/alfresco_strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~  Copyright (C) 2005-2015 Alfresco Software Limited.
   ~
   ~  This file is part of Alfresco Mobile for Android.


### PR DESCRIPTION
Here's the original story https://issues.alfresco.com/jira/browse/ANDROID-564 and this is the referenced story https://issues.alfresco.com/jira/browse/MNT-17964

I've added all the string files that have differences.