### PR TITLE
ANDROID-630 Crash on DocumentFolderBrowserFragment.getPath()

### DIFF
--- a/alfresco-mobile-android/src/main/java/org/alfresco/mobile/android/application/fragments/node/browser/DocumentFolderBrowserFragment.java
+++ b/alfresco-mobile-android/src/main/java/org/alfresco/mobile/android/application/fragments/node/browser/DocumentFolderBrowserFragment.java
@@ -538,6 +538,9 @@ public class DocumentFolderBrowserFragment extends NodeBrowserFragment implement
 
     private List<String> getPath(String pathValue, boolean fromSite)
     {
+        if (pathValue == null) {
+            pathValue = "";
+        }
         String[] path = pathValue.split("/");
         if (path.length == 0)
         {


### PR DESCRIPTION
JIRA https://issues.alfresco.com/jira/browse/ANDROID-630